### PR TITLE
Dtg 102 fix mock output in terragrunt secrets

### DIFF
--- a/terraform/modules/gcp_helm/provider_helm.tf
+++ b/terraform/modules/gcp_helm/provider_helm.tf
@@ -1,10 +1,20 @@
 provider "helm" {
   kubernetes {
-    config_path = "~/.kube/config"
-    host        = var.kuber_host
-    #    insecure    = true
+    #  config_path = "~/.kube/config"
+    host                   = var.kuber_host
     cluster_ca_certificate = base64decode(var.cluster_ca_certificate)
-    client_certificate     = base64decode(var.client_certificate)
-    client_key             = base64decode(var.client_key)
+    token                  = data.google_client_config.default.access_token
   }
+}
+
+data "google_container_cluster" "default" {
+  name     = "cluster-${var.env}"
+  location = var.zone
+}
+
+data "google_client_config" "default" {}
+
+output "token" {
+  value     = data.google_client_config.default.access_token
+  sensitive = true
 }

--- a/terraform/modules/gcp_helm/var.tf
+++ b/terraform/modules/gcp_helm/var.tf
@@ -6,10 +6,10 @@ variable "chart_name" {
   type = string
 }
 
-#variable "chart_repository" {
-#  description = "path to chart repo"
-#  type        = string
-#}
+variable "zone" {
+  description = "zone where cluster is located, e.g. us-west2-b "
+  type        = string
+}
 
 variable "kuber_host" {
   description = "url to reach Cluster"

--- a/terraform/modules/gcp_helm/var.tf
+++ b/terraform/modules/gcp_helm/var.tf
@@ -65,10 +65,10 @@ variable "cluster_ca_certificate" {
   description = "Base64-encoded Kubernetes cluster CA certificate used for server verification."
 }
 
-variable "client_certificate" {
-  description = "Base64-encoded client certificate used for authentication with the Kubernetes cluster."
-}
-
-variable "client_key" {
-  description = "Base64-encoded client private key used for authentication with the Kubernetes cluster."
-}
+#variable "client_certificate" {
+#  description = "Base64-encoded client certificate used for authentication with the Kubernetes cluster."
+#}
+#
+#variable "client_key" {
+#  description = "Base64-encoded client private key used for authentication with the Kubernetes cluster."
+#}

--- a/terraform/modules/gcp_namespaces/create_secret_token.tf
+++ b/terraform/modules/gcp_namespaces/create_secret_token.tf
@@ -1,0 +1,16 @@
+# This part to Save Cluster Token in GCP Secret Manager
+resource "google_secret_manager_secret" "cluster-token" {
+  secret_id = "CLUSTER-TOKEN-${var.env}"
+ replication {
+    user_managed {
+      replicas {
+        location = "us-west2"
+      }
+    }
+  }
+}
+
+resource "google_secret_manager_secret_version" "cluster-token" {
+  secret      = google_secret_manager_secret.cluster-token.id
+  secret_data = data.google_client_config.default.access_token
+}

--- a/terraform/modules/gcp_namespaces/provider_kuber.tf
+++ b/terraform/modules/gcp_namespaces/provider_kuber.tf
@@ -1,11 +1,18 @@
 provider "kubernetes" {
-  config_path = "~/.kube/config"
-  host        = var.kuber_host
-  #  insecure    = true
-
+  #  config_path = "~/.kube/config"
+  host                   = var.kuber_host
   cluster_ca_certificate = base64decode(var.cluster_ca_certificate)
-  client_certificate     = base64decode(var.client_certificate)
-  client_key             = base64decode(var.client_key)
+  token                  = data.google_client_config.default.access_token
 }
 
+data "google_container_cluster" "default" {
+  name     = "cluster-${var.env}"
+  location = var.zone
+}
 
+data "google_client_config" "default" {}
+
+output "token" {
+  value     = data.google_client_config.default.access_token
+  sensitive = true
+}

--- a/terraform/modules/gcp_namespaces/provider_kuber.tf
+++ b/terraform/modules/gcp_namespaces/provider_kuber.tf
@@ -11,8 +11,3 @@ data "google_container_cluster" "default" {
 }
 
 data "google_client_config" "default" {}
-
-output "token" {
-  value     = data.google_client_config.default.access_token
-  sensitive = true
-}

--- a/terraform/modules/gcp_namespaces/var.tf
+++ b/terraform/modules/gcp_namespaces/var.tf
@@ -15,14 +15,6 @@ variable "cluster_ca_certificate" {
   description = "Base64-encoded Kubernetes cluster CA certificate used for server verification."
 }
 
-variable "client_certificate" {
-  description = "Base64-encoded client certificate used for authentication with the Kubernetes cluster."
-}
-
-variable "client_key" {
-  description = "Base64-encoded client private key used for authentication with the Kubernetes cluster."
-}
-
 variable "namespace" {
   default = ["consul", "app", "monitoring"]
   type    = list(string)

--- a/terraform/modules/gcp_namespaces/var.tf
+++ b/terraform/modules/gcp_namespaces/var.tf
@@ -1,3 +1,11 @@
+variable "env" {
+  type = string
+}
+
+variable "zone" {
+  type = string
+}
+
 variable "kuber_host" {
   description = "url to reach Cluster"
   type        = string

--- a/terragrunt/_envcommon/helm_api_gw.hcl
+++ b/terragrunt/_envcommon/helm_api_gw.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "git::https://github.com/DTG-cisco/devops-team-green-2.git//terraform/modules/gcp_helm"
+  source = "git::https://github.com/DTG-cisco/devops-team-green-2.git//terraform/modules/gcp_helm?ref=DTG-102-fix-mock-output-in-terragrunt-secrets"
 }
 
 dependencies {
@@ -17,11 +17,6 @@ dependency "cluster_ip" {
   }
 }
 
-dependency "cluster_namespaces" {
-  config_path  = "../kuber_namespaces"
-  skip_outputs = true
-}
-
 locals {
   environment_vars = read_terragrunt_config(find_in_parent_folders("env.hcl"))
   env              = local.environment_vars.locals.environment
@@ -29,17 +24,16 @@ locals {
   namespace        = local.environment_vars.locals.namespace
   chart_n          = local.environment_vars.locals.chart_api_gw
   repository       = local.environment_vars.locals.repo_api_gw
+  zone             = local.environment_vars.locals.zone
 }
 
 inputs = {
   app                    = "${local.app}"
-  cluster_ca_certificate = dependency.cluster_ip.outputs.cluster_ca_certificate
-  client_certificate     = dependency.cluster_ip.outputs.client_certificate
-  client_key             = dependency.cluster_ip.outputs.client_key
-
   env        = "${local.env}"
+  zone       = "${local.zone}"
   namespace  = "${local.namespace}"
   chart_name = "${local.chart_n}"
   repository = "${local.repository}"
   kuber_host = "https://${dependency.cluster_ip.outputs.cluster_endpoint}"
+  cluster_ca_certificate = dependency.cluster_ip.outputs.cluster_ca_certificate
 }

--- a/terragrunt/_envcommon/helm_api_gw.hcl
+++ b/terragrunt/_envcommon/helm_api_gw.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "git::https://github.com/DTG-cisco/devops-team-green-2.git//terraform/modules/gcp_helm?ref=DTG-102-fix-mock-output-in-terragrunt-secrets"
+  source = "git::https://github.com/DTG-cisco/devops-team-green-2.git//terraform/modules/gcp_helm"
 }
 
 dependencies {

--- a/terragrunt/_envcommon/helm_api_gw.hcl
+++ b/terragrunt/_envcommon/helm_api_gw.hcl
@@ -29,11 +29,11 @@ locals {
 
 inputs = {
   app                    = "${local.app}"
-  env        = "${local.env}"
-  zone       = "${local.zone}"
-  namespace  = "${local.namespace}"
-  chart_name = "${local.chart_n}"
-  repository = "${local.repository}"
-  kuber_host = "https://${dependency.cluster_ip.outputs.cluster_endpoint}"
+  env                    = "${local.env}"
+  zone                   = "${local.zone}"
+  namespace              = "${local.namespace}"
+  chart_name             = "${local.chart_n}"
+  repository             = "${local.repository}"
+  kuber_host             = "https://${dependency.cluster_ip.outputs.cluster_endpoint}"
   cluster_ca_certificate = dependency.cluster_ip.outputs.cluster_ca_certificate
 }

--- a/terragrunt/_envcommon/helm_consul.hcl
+++ b/terragrunt/_envcommon/helm_consul.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "git::https://github.com/DTG-cisco/devops-team-green-2.git//terraform/modules/gcp_helm"
+  source = "git::https://github.com/DTG-cisco/devops-team-green-2.git//terraform/modules/gcp_helm?ref=DTG-102-fix-mock-output-in-terragrunt-secrets"
 }
 
 dependencies {
@@ -17,11 +17,6 @@ dependency "cluster_ip" {
   }
 }
 
-dependency "cluster_namespaces" {
-  config_path  = "../kuber_namespaces"
-  skip_outputs = true
-}
-
 locals {
   environment_vars = read_terragrunt_config(find_in_parent_folders("env.hcl"))
   env              = local.environment_vars.locals.environment
@@ -29,6 +24,7 @@ locals {
   namespace        = local.environment_vars.locals.namespace
   chart_n          = local.environment_vars.locals.chart_name_consul
   repository       = local.environment_vars.locals.repository_consul
+  zone             = local.environment_vars.locals.zone
 }
 
 inputs = {
@@ -42,10 +38,10 @@ inputs = {
     create_namespace = true
   }
   #  values                 = ["${file("consul-config.yaml")}"]
+  #  client_certificate     = dependency.cluster_ip.outputs.client_certificate
+  #  client_key             = dependency.cluster_ip.outputs.client_key
   cluster_ca_certificate = dependency.cluster_ip.outputs.cluster_ca_certificate
-  client_certificate     = dependency.cluster_ip.outputs.client_certificate
-  client_key             = dependency.cluster_ip.outputs.client_key
-
+  zone                   = "${local.zone}"
   env        = "${local.env}"
   namespace  = "${local.namespace}"
   chart_name = "${local.chart_n}"

--- a/terragrunt/_envcommon/helm_consul.hcl
+++ b/terragrunt/_envcommon/helm_consul.hcl
@@ -37,14 +37,11 @@ inputs = {
     version          = "1.3.1"
     create_namespace = true
   }
-  #  values                 = ["${file("consul-config.yaml")}"]
-  #  client_certificate     = dependency.cluster_ip.outputs.client_certificate
-  #  client_key             = dependency.cluster_ip.outputs.client_key
   cluster_ca_certificate = dependency.cluster_ip.outputs.cluster_ca_certificate
   zone                   = "${local.zone}"
-  env        = "${local.env}"
-  namespace  = "${local.namespace}"
-  chart_name = "${local.chart_n}"
-  repository = "${local.repository}"
-  kuber_host = "https://${dependency.cluster_ip.outputs.cluster_endpoint}"
+  env                    = "${local.env}"
+  namespace              = "${local.namespace}"
+  chart_name             = "${local.chart_n}"
+  repository             = "${local.repository}"
+  kuber_host             = "https://${dependency.cluster_ip.outputs.cluster_endpoint}"
 }

--- a/terragrunt/_envcommon/helm_consul.hcl
+++ b/terragrunt/_envcommon/helm_consul.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "git::https://github.com/DTG-cisco/devops-team-green-2.git//terraform/modules/gcp_helm?ref=DTG-102-fix-mock-output-in-terragrunt-secrets"
+  source = "git::https://github.com/DTG-cisco/devops-team-green-2.git//terraform/modules/gcp_helm"
 }
 
 dependencies {

--- a/terragrunt/_envcommon/namespaces.hcl
+++ b/terragrunt/_envcommon/namespaces.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "git::https://github.com/DTG-cisco/devops-team-green-2.git//terraform/modules/gcp_namespaces?ref=DTG-102-fix-mock-output-in-terragrunt-secrets"
+  source = "git::https://github.com/DTG-cisco/devops-team-green-2.git//terraform/modules/gcp_namespaces"
 }
 
 dependencies {

--- a/terragrunt/_envcommon/namespaces.hcl
+++ b/terragrunt/_envcommon/namespaces.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "git::https://github.com/DTG-cisco/devops-team-green-2.git//terraform/modules/gcp_namespaces"
+  source = "git::https://github.com/DTG-cisco/devops-team-green-2.git//terraform/modules/gcp_namespaces?ref=DTG-102-fix-mock-output-in-terragrunt-secrets"
 }
 
 dependencies {
@@ -20,12 +20,14 @@ dependency "cluster_ip" {
 locals {
   environment_vars = read_terragrunt_config(find_in_parent_folders("env.hcl"))
   namespace        = local.environment_vars.locals.namespace
+  env              = local.environment_vars.locals.environment
+  zone             = local.environment_vars.locals.zone
 }
 
 inputs = {
+  env                    = "${local.env}"
+  zone                   = "${local.zone}"
   cluster_ca_certificate = dependency.cluster_ip.outputs.cluster_ca_certificate
-  client_certificate     = dependency.cluster_ip.outputs.client_certificate
-  client_key             = dependency.cluster_ip.outputs.client_key
   namespace              = ["consul", "app", "monitoring", "customnames"]
   kuber_host             = "https://${dependency.cluster_ip.outputs.cluster_endpoint}"
 }

--- a/terragrunt/dev/env.hcl
+++ b/terragrunt/dev/env.hcl
@@ -5,7 +5,7 @@ locals {
   zone              = "us-west2-b"
   project_id        = "cisco-team-green"
   count_nodes       = 3
-  node_machine_type = "e2-small"
+  node_machine_type = "e2-medium"
   serv_account      = "awx-350@cisco-team-green.iam.gserviceaccount.com"
 
   # For Consul (helm)

--- a/terragrunt/dev/helm_backend/terragrunt.hcl
+++ b/terragrunt/dev/helm_backend/terragrunt.hcl
@@ -16,6 +16,11 @@ dependency "mongo_db" {
 
 dependency "secret_manager" {
   config_path = "../secret_manager"
+  mock_outputs_allowed_terraform_commands = ["init", "validate", "plan", "destroy"]
+  mock_outputs = {
+    nexus_token  = "mock_token"
+    pg_passw     = "mock_password"
+  }
 }
 
 dependency "pg_db" {

--- a/terragrunt/dev/helm_backend/terragrunt.hcl
+++ b/terragrunt/dev/helm_backend/terragrunt.hcl
@@ -3,7 +3,7 @@ include "root" {
 }
 
 terraform {
-  source = "git::https://github.com/DTG-cisco/devops-team-green-2.git//terraform/modules/gcp_helm"
+  source = "git::https://github.com/DTG-cisco/devops-team-green-2.git//terraform/modules/gcp_helm?ref=DTG-102-fix-mock-output-in-terragrunt-secrets"
 }
 
 dependencies {

--- a/terragrunt/dev/helm_backend/terragrunt.hcl
+++ b/terragrunt/dev/helm_backend/terragrunt.hcl
@@ -3,7 +3,7 @@ include "root" {
 }
 
 terraform {
-  source = "git::https://github.com/DTG-cisco/devops-team-green-2.git//terraform/modules/gcp_helm?ref=DTG-102-fix-mock-output-in-terragrunt-secrets"
+  source = "git::https://github.com/DTG-cisco/devops-team-green-2.git//terraform/modules/gcp_helm"
 }
 
 dependencies {

--- a/terragrunt/dev/helm_backend/terragrunt.hcl
+++ b/terragrunt/dev/helm_backend/terragrunt.hcl
@@ -55,18 +55,20 @@ locals {
   repository       = local.environment_vars.locals.repo_front
   chart_n          = local.environment_vars.locals.chart_front
   namespace_app    = local.environment_vars.locals.namespace
-
-  be_img_name = local.environment_vars.locals.backend_image_name
-  be_img_tag  = local.environment_vars.locals.backend_image_tag
+  zone             = local.environment_vars.locals.zone
+  be_img_name      = local.environment_vars.locals.backend_image_name
+  be_img_tag       = local.environment_vars.locals.backend_image_tag
 }
 
 inputs = {
   app        = "${local.app}"
   env        = "${local.env}"
+  zone       = "${local.zone}"
   namespace  = "${local.namespace_app}"
   chart_name = "${local.chart_n}"
   repository = "${local.repository}"
   kuber_host = "https://${dependency.cluster_ip.outputs.cluster_endpoint}"
+  cluster_ca_certificate = dependency.cluster_ip.outputs.cluster_ca_certificate
 
   set = [
     #    https://github.com/terraform-module/terraform-helm-release
@@ -112,7 +114,4 @@ inputs = {
     }
   ]
 
-  cluster_ca_certificate = dependency.cluster_ip.outputs.cluster_ca_certificate
-  client_certificate     = dependency.cluster_ip.outputs.client_certificate
-  client_key             = dependency.cluster_ip.outputs.client_key
 }

--- a/terragrunt/dev/helm_consul/consul-config.yaml
+++ b/terragrunt/dev/helm_consul/consul-config.yaml
@@ -4,7 +4,7 @@
 ui:
   enabled: true
   service:
-    type: LoadBalancer
+    type: ClusterIP
 #  metrics:
 #    enabled: true
 #    provider: "prometheus"
@@ -15,6 +15,8 @@ global:
   enabled: true
   name: consul
   datacenter: gcp-dev
+  peering:
+    enabled: true
   tls:
     enabled: true
   acls:
@@ -28,7 +30,7 @@ global:
 server:
   enabled: true
   # The number of server agents to run. This determines the fault tolerance of the cluster.
-  replicas: 1
+  replicas: 3
 
 # Enable Consul connect pod injection
 connectInject:
@@ -42,6 +44,6 @@ connectInject:
       serviceType: LoadBalancer
 
 # Reach Other DC
-#meshGateway:
-#  enabled: true
+meshGateway:
+  enabled: true # mandatory for k8s cluster peering
 #  replicas: 1

--- a/terragrunt/dev/helm_consul/consul-config.yaml
+++ b/terragrunt/dev/helm_consul/consul-config.yaml
@@ -4,7 +4,7 @@
 ui:
   enabled: true
   service:
-    type: ClusterIP
+    type: LoadBalancer
 #  metrics:
 #    enabled: true
 #    provider: "prometheus"

--- a/terragrunt/dev/helm_front/terragrunt.hcl
+++ b/terragrunt/dev/helm_front/terragrunt.hcl
@@ -71,6 +71,5 @@ inputs = {
     },
   ]
   cluster_ca_certificate = dependency.cluster_ip.outputs.cluster_ca_certificate
-  client_certificate     = dependency.cluster_ip.outputs.client_certificate
-  client_key             = dependency.cluster_ip.outputs.client_key
+
 }

--- a/terragrunt/dev/helm_front/terragrunt.hcl
+++ b/terragrunt/dev/helm_front/terragrunt.hcl
@@ -3,7 +3,7 @@ include "root" {
 }
 
 terraform {
-  source = "git::https://github.com/DTG-cisco/devops-team-green-2.git//terraform/modules/gcp_helm"
+  source = "git::https://github.com/DTG-cisco/devops-team-green-2.git//terraform/modules/gcp_helm?ref=DTG-102-fix-mock-output-in-terragrunt-secrets"
   # source = "tfr:///terraform-module/release/helm?version=2.8.1"
 }
 
@@ -31,11 +31,6 @@ dependency "cluster_ip" {
   }
 }
 
-dependency "cluster_namespaces" {
-  config_path  = "../kuber_namespaces"
-  skip_outputs = true
-}
-
 locals {
   environment_vars = read_terragrunt_config(find_in_parent_folders("env.hcl"))
   env              = local.environment_vars.locals.environment
@@ -43,14 +38,15 @@ locals {
   repository       = local.environment_vars.locals.repo_front
   chart_n          = local.environment_vars.locals.chart_front
   namespace_app    = local.environment_vars.locals.namespace
-
-  fe_img_name = local.environment_vars.locals.frontend_image_name
-  fe_img_tag  = local.environment_vars.locals.frontend_image_tag
+  zone             = local.environment_vars.locals.zone
+  fe_img_name      = local.environment_vars.locals.frontend_image_name
+  fe_img_tag       = local.environment_vars.locals.frontend_image_tag
 }
 
 inputs = {
   app        = "${local.app}"
   env        = "${local.env}"
+  zone       = "${local.zone}"
   namespace  = "${local.namespace_app}"
   chart_name = "${local.chart_n}"
   repository = "${local.repository}"

--- a/terragrunt/dev/helm_front/terragrunt.hcl
+++ b/terragrunt/dev/helm_front/terragrunt.hcl
@@ -3,7 +3,7 @@ include "root" {
 }
 
 terraform {
-  source = "git::https://github.com/DTG-cisco/devops-team-green-2.git//terraform/modules/gcp_helm?ref=DTG-102-fix-mock-output-in-terragrunt-secrets"
+  source = "git::https://github.com/DTG-cisco/devops-team-green-2.git//terraform/modules/gcp_helm"
   # source = "tfr:///terraform-module/release/helm?version=2.8.1"
 }
 

--- a/terragrunt/errors.md
+++ b/terragrunt/errors.md
@@ -1,6 +1,6 @@
 ### Common Errors when running Terragrunt:
 
-### LoadBalancer IP is always <pending>
+### LoadBalancer IP is always `<pending>`
 Reason:
 ```text
 NAMESPACE     NAME                     TYPE           CLUSTER-IP     EXTERNAL-IP      PORT(S) 
@@ -12,8 +12,10 @@ Warning  SyncLoadBalancerFailed  89s (x10 over 22m)   service-controller
 Error syncing load balancer: failed to ensure load balancer: failed to create forwarding rule for load balancer (afe5955ae6fac499ea7143d94ea61381(consul/gateway-front)): 
 googleapi: Error 403: QUOTA_EXCEEDED - Quota 'IN_USE_ADDRESSES' exceeded.  Limit: 4.0 globally.
 ```
+how to fix:
+Delete some unused [LoadBalancer IP](https://console.cloud.google.com/net-services/loadbalancing/list/loadBalancers)
 
-
+------------------------------------------
 ### Cluster with only One node: "e2-medium" (need minimum 3)
 
 ```text

--- a/terragrunt/prod/helm_backend/terragrunt.hcl
+++ b/terragrunt/prod/helm_backend/terragrunt.hcl
@@ -16,6 +16,11 @@ dependency "mongo_db" {
 
 dependency "secret_manager" {
   config_path = "../secret_manager"
+  mock_outputs_allowed_terraform_commands = ["init", "validate", "plan", "destroy"]
+  mock_outputs = {
+    nexus_token  = "mock_token"
+    pg_passw     = "mock_password"
+  }
 }
 
 dependency "pg_db" {
@@ -50,19 +55,20 @@ locals {
   repository       = local.environment_vars.locals.repo_front
   chart_n          = local.environment_vars.locals.chart_front
   namespace_app    = local.environment_vars.locals.namespace
-
-  be_img_name = local.environment_vars.locals.backend_image_name
-  be_img_tag  = local.environment_vars.locals.backend_image_tag
+  zone             = local.environment_vars.locals.zone
+  be_img_name      = local.environment_vars.locals.backend_image_name
+  be_img_tag       = local.environment_vars.locals.backend_image_tag
 }
 
 inputs = {
   app        = "${local.app}"
   env        = "${local.env}"
+  zone       = "${local.zone}"
   namespace  = "${local.namespace_app}"
   chart_name = "${local.chart_n}"
   repository = "${local.repository}"
   kuber_host = "https://${dependency.cluster_ip.outputs.cluster_endpoint}"
-
+  cluster_ca_certificate = dependency.cluster_ip.outputs.cluster_ca_certificate
   set = [
     #    https://github.com/terraform-module/terraform-helm-release
     {
@@ -106,8 +112,4 @@ inputs = {
       value = dependency.secret_manager.outputs.pg_passw
     }
   ]
-
-  cluster_ca_certificate = dependency.cluster_ip.outputs.cluster_ca_certificate
-  client_certificate     = dependency.cluster_ip.outputs.client_certificate
-  client_key             = dependency.cluster_ip.outputs.client_key
 }

--- a/terragrunt/prod/helm_consul/consul-config.yaml
+++ b/terragrunt/prod/helm_consul/consul-config.yaml
@@ -4,7 +4,7 @@
 ui:
   enabled: true
   service:
-    type: ClusterIP
+    type: LoadBalancer
 #  metrics:
 #    enabled: true
 #    provider: "prometheus"

--- a/terragrunt/prod/helm_consul/consul-config.yaml
+++ b/terragrunt/prod/helm_consul/consul-config.yaml
@@ -4,7 +4,7 @@
 ui:
   enabled: true
   service:
-    type: LoadBalancer
+    type: ClusterIP
 #  metrics:
 #    enabled: true
 #    provider: "prometheus"
@@ -14,7 +14,9 @@ ui:
 global:
   enabled: true
   name: consul
-  datacenter: gcp-dev
+  datacenter: gcp-prod
+  peering:
+    enabled: true
   tls:
     enabled: true
   acls:
@@ -28,7 +30,7 @@ global:
 server:
   enabled: true
   # The number of server agents to run. This determines the fault tolerance of the cluster.
-  replicas: 1
+  replicas: 3
 
 # Enable Consul connect pod injection
 connectInject:
@@ -42,6 +44,6 @@ connectInject:
       serviceType: LoadBalancer
 
 # Reach Other DC
-#meshGateway:
-#  enabled: true
+meshGateway:
+  enabled: true
 #  replicas: 1

--- a/terragrunt/prod/helm_front/terragrunt.hcl
+++ b/terragrunt/prod/helm_front/terragrunt.hcl
@@ -43,14 +43,15 @@ locals {
   repository       = local.environment_vars.locals.repo_front
   chart_n          = local.environment_vars.locals.chart_front
   namespace_app    = local.environment_vars.locals.namespace
-
-  fe_img_name = local.environment_vars.locals.frontend_image_name
-  fe_img_tag  = local.environment_vars.locals.frontend_image_tag
+  zone             = local.environment_vars.locals.zone
+  fe_img_name      = local.environment_vars.locals.frontend_image_name
+  fe_img_tag       = local.environment_vars.locals.frontend_image_tag
 }
 
 inputs = {
   app        = "${local.app}"
   env        = "${local.env}"
+  zone       = "${local.zone}"
   namespace  = "${local.namespace_app}"
   chart_name = "${local.chart_n}"
   repository = "${local.repository}"
@@ -75,6 +76,4 @@ inputs = {
     },
   ]
   cluster_ca_certificate = dependency.cluster_ip.outputs.cluster_ca_certificate
-  client_certificate     = dependency.cluster_ip.outputs.client_certificate
-  client_key             = dependency.cluster_ip.outputs.client_key
 }

--- a/terragrunt/stage/helm_backend/terragrunt.hcl
+++ b/terragrunt/stage/helm_backend/terragrunt.hcl
@@ -16,6 +16,11 @@ dependency "mongo_db" {
 
 dependency "secret_manager" {
   config_path = "../secret_manager"
+  mock_outputs_allowed_terraform_commands = ["init", "validate", "plan", "destroy"]
+  mock_outputs = {
+    nexus_token  = "mock_token"
+    pg_passw     = "mock_password"
+  }
 }
 
 dependency "pg_db" {
@@ -50,18 +55,20 @@ locals {
   repository       = local.environment_vars.locals.repo_front
   chart_n          = local.environment_vars.locals.chart_front
   namespace_app    = local.environment_vars.locals.namespace
-
-  be_img_name = local.environment_vars.locals.backend_image_name
-  be_img_tag  = local.environment_vars.locals.backend_image_tag
+  zone             = local.environment_vars.locals.zone
+  be_img_name      = local.environment_vars.locals.backend_image_name
+  be_img_tag       = local.environment_vars.locals.backend_image_tag
 }
 
 inputs = {
   app        = "${local.app}"
   env        = "${local.env}"
+  zone       = "${local.zone}"
   namespace  = "${local.namespace_app}"
   chart_name = "${local.chart_n}"
   repository = "${local.repository}"
   kuber_host = "https://${dependency.cluster_ip.outputs.cluster_endpoint}"
+  cluster_ca_certificate = dependency.cluster_ip.outputs.cluster_ca_certificate
 
   set = [
     #    https://github.com/terraform-module/terraform-helm-release
@@ -106,8 +113,4 @@ inputs = {
       value = dependency.secret_manager.outputs.pg_passw
     }
   ]
-
-  cluster_ca_certificate = dependency.cluster_ip.outputs.cluster_ca_certificate
-  client_certificate     = dependency.cluster_ip.outputs.client_certificate
-  client_key             = dependency.cluster_ip.outputs.client_key
 }

--- a/terragrunt/stage/helm_consul/consul-config.yaml
+++ b/terragrunt/stage/helm_consul/consul-config.yaml
@@ -4,7 +4,7 @@
 ui:
   enabled: true
   service:
-    type: LoadBalancer
+    type: ClusterIP
 #  metrics:
 #    enabled: true
 #    provider: "prometheus"
@@ -14,7 +14,9 @@ ui:
 global:
   enabled: true
   name: consul
-  datacenter: gcp-dev
+  datacenter: gcp-stage
+  peering:
+    enabled: true
   tls:
     enabled: true
   acls:
@@ -28,7 +30,7 @@ global:
 server:
   enabled: true
   # The number of server agents to run. This determines the fault tolerance of the cluster.
-  replicas: 1
+  replicas: 3
 
 # Enable Consul connect pod injection
 connectInject:
@@ -42,6 +44,6 @@ connectInject:
       serviceType: LoadBalancer
 
 # Reach Other DC
-#meshGateway:
-#  enabled: true
+meshGateway:
+  enabled: true
 #  replicas: 1

--- a/terragrunt/stage/helm_front/terragrunt.hcl
+++ b/terragrunt/stage/helm_front/terragrunt.hcl
@@ -43,14 +43,15 @@ locals {
   repository       = local.environment_vars.locals.repo_front
   chart_n          = local.environment_vars.locals.chart_front
   namespace_app    = local.environment_vars.locals.namespace
-
-  fe_img_name = local.environment_vars.locals.frontend_image_name
-  fe_img_tag  = local.environment_vars.locals.frontend_image_tag
+  zone             = local.environment_vars.locals.zone
+  fe_img_name      = local.environment_vars.locals.frontend_image_name
+  fe_img_tag       = local.environment_vars.locals.frontend_image_tag
 }
 
 inputs = {
   app        = "${local.app}"
   env        = "${local.env}"
+  zone       = "${local.zone}"
   namespace  = "${local.namespace_app}"
   chart_name = "${local.chart_n}"
   repository = "${local.repository}"


### PR DESCRIPTION
# Description
The primary issue was from the Kuber Cluster provider connection. Locally, the connection functioned properly due to the presence of the gonfig file `.kube/config` stored in the local Home directory. However, when executing commands remotely, such as on a server, a token was required to access the cluster.e.

[Jira-102](https://dtg-projects.atlassian.net/browse/DTG-102)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds to Secret Manager Kubernetes Token)

# How Has This Been Tested?
- [x] Test in dev Environment  [ Git actions](https://github.com/DTG-cisco/devops-team-green-2/actions/runs/7371422998)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

